### PR TITLE
[CM-137] sprint effective mandays 조건 미충족시 action 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ asset/
 # 모델 학습 및 평가에 사용된 데이터 파일 dismiss
 Korpora/
 AI_hub/
+bge-m3-training.py
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos,pycharm,visualstudiocode,python
 # Edit at https://www.toptal.com/developers/gitignore?templates=macos,pycharm,visualstudiocode,python


### PR DESCRIPTION
## 🔗 Jira Ticket
- 관련 지라 티켓: [CM-137](https://starmix.atlassian.net/browse/CM-137?atlOrigin=eyJpIjoiODkxN2IzOWZjMWE1NDkxNGFjN2I0YWFlZjU0M2MzOTMiLCJwIjoiaiJ9)

## 📌 PR Type
- [x] ✨ Feature  
- [ ] 🐛 Bugfix  
- [ ] 🛠️ Refactor  
- [ ] 📝 Docs  
- [ ] 🎨 Design  
- [ ] ✅ Test  
- [ ] ⚡ Chore  

## 📝 작업 내용
- [x] 주요 변경 사항을 간략히 설명해주세요.
- [x] sprint effective mandays 조건 미충족시 gpt를 재호출하여 expected_days를 수정하는 로직 추가

## 📸 스크린샷 (선택)
(필요한 경우 UI 변경 사항을 캡쳐해서 첨부해주세요.)
