### PR TITLE
[CM-160] Sprint 생성 API 변경 사항 반영

### DIFF
--- a/mvp/requirements.txt
+++ b/mvp/requirements.txt
@@ -80,6 +80,7 @@ pytest==8.3.5
 pytest-asyncio==0.26.0
 python-dateutil==2.9.0.post0
 python-dotenv==1.1.0
+python-multipart==0.0.20
 pytz==2025.2
 PyYAML==6.0.2
 redis==5.2.1
@@ -108,7 +109,7 @@ transformers==4.51.3
 typing-inspect==0.9.0
 typing-inspection==0.4.0
 typing_extensions==4.13.2
-#tzdata==2025.2
+tzdata==2025.2
 urllib3==2.4.0
 uvicorn==0.34.2
 xlrd==2.0.1

--- a/mvp/serve.py
+++ b/mvp/serve.py
@@ -8,13 +8,15 @@ import httpx
 import redis.asyncio as aioredis
 from create_epic import create_sprint
 from dotenv import load_dotenv
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import FastAPI, File, HTTPException, Request, UploadFile
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from feature_definition import (create_feature_definition,
                                 update_feature_definition)
 from feature_specification import (create_feature_specification,
                                    update_feature_specification)
+from meeting_analysis import (analyze_meeting_document,
+                              convert_action_items_to_tasks)
 from mongodb_setting import test_mongodb_connection
 from pydantic import BaseModel
 from redis_setting import test_redis_connection
@@ -52,6 +54,16 @@ class EpicPOSTRequest(BaseModel):
     pendingTasksIds: Optional[List[str]] = None
     startDate: datetime
 
+class MeetingPOSTRequest(BaseModel):
+    meetingId: str
+    title: str
+    content: str
+    projectId: str
+
+class CreateActionItemPOSTRequest(BaseModel):
+    actionItems: List[str]
+    projectId: str
+
 
 ### 응답 모델
 class FeatureDefinitionSuggestion(BaseModel):
@@ -79,6 +91,14 @@ class FeedbackFeatureSpecificationResponse(BaseModel):
 class CreateSprintResponse(BaseModel):
     sprint: Dict[str, Any]
     epics: List[Dict[str, Any]]
+    
+class CreateMeetingResponse(BaseModel):
+    summary: str
+    actionItems: List[str]
+    
+class CreateActionItemResponse(BaseModel):
+    tasks: List[Dict[str, Any]]
+
 
 app = FastAPI(docs_url="/docs")
 
@@ -189,6 +209,40 @@ async def post_epic(request: EpicPOSTRequest):
             status_code=500,
             detail=f"스프린트 생성 중 오류 발생: {str(e)}"
         )
+
+
+@app.post("/meeting", response_model=CreateMeetingResponse)
+async def post_meeting(request: MeetingPOSTRequest):
+    try:
+        #content = await file.read()
+        #content = content.decode('utf-8')
+        logger.info(f"📨 POST /meeting 요청 수신: {request}")
+        logger.info(f"📨 요청 시간: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        result = await analyze_meeting_document(request.meetingId, request.title, request.content, request.projectId)
+        logger.info(f"✅ 처리 결과: {result}")
+        return result
+    except Exception as e:
+        logger.error(f"🔥 예외 발생: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"회의록 요약 중 오류 발생: {str(e)}"
+        )
+
+@app.post("/meeting/action-items", response_model=CreateActionItemResponse)
+async def post_action_items(request: CreateActionItemPOSTRequest):
+    try:
+        logger.info(f"📨 POST /meeting/action-items 요청 수신: {request}")
+        logger.info(f"📨 요청 시간: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
+        result = await convert_action_items_to_tasks(request.actionItems, request.projectId)
+        logger.info(f"✅ 처리 결과: {result}")
+        return result
+    except Exception as e:
+        logger.error(f"🔥 예외 발생: {str(e)}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail=f"회의록 액션 아이템 생성 중 오류 발생: {str(e)}"
+        )
+
 
 # 실행 예시
 if __name__ == "__main__":


### PR DESCRIPTION
## 🔗 Jira Ticket
- 관련 지라 티켓: [CM-160](https://starmix.atlassian.net/browse/CM-160?atlOrigin=eyJpIjoiZjQ5NDY1M2RiYWYwNDM2MzgwNDk5M2NkNTFjNjg3ZGQiLCJwIjoiaiJ9)

## 📌 PR Type
- [x] ✨ Feature  
- [ ] 🐛 Bugfix  
- [ ] 🛠️ Refactor  
- [ ] 📝 Docs  
- [ ] 🎨 Design  
- [x] ✅ Test  
- [ ] ⚡ Chore  

## 📝 작업 내용
- [x] 주요 변경 사항을 간략히 설명해주세요. 
- [x] POST /sprint request에 startDate: datetime 필드 추가
- [x] create_sprint() 내부의 함수 로직에서 startDate를 기준으로 sprint를 생성하도록 로직 수정
- [x] task 생성 로직 분기 -> 기존에는 task가 정의된 epic인지만 판단했으나 featureId의 여부에 따라 create_task의 유형을 from_null과 from_epic으로 한 번 더 구분하여 처리함
- [x] 상위의 변경 항목에 대해 localhost:8000 환경에서 테스트 완료  

## 📸 스크린샷 (선택)
(필요한 경우 UI 변경 사항을 캡쳐해서 첨부해주세요.)
